### PR TITLE
Allowing command to work with spaces in path

### DIFF
--- a/gh-org-clone
+++ b/gh-org-clone
@@ -9,7 +9,7 @@ fi
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # Pass arguments through to another command
-node ${SCRIPT_DIR}/gh-org-clone.js "$@" 
+node "${SCRIPT_DIR}/gh-org-clone.js" "$@" 
 
 # Using the gh api command to retrieve and format information
 # QUERY='


### PR DESCRIPTION
Windows installed the extension in "%APPDATA%\Local\GitHub CLI", so I had to add quotes around the path to make it work. 